### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/carlescs/TestFizzBuzz/security/code-scanning/1](https://github.com/carlescs/TestFizzBuzz/security/code-scanning/1)

The problem is best fixed by explicitly adding a `permissions` block with the minimum required privileges. For a typical .NET build-and-test workflow that uploads artifacts but does not modify code, open PRs, or deploy, `contents: read` is usually sufficient. The recommended practice is to add the following at the top level, right after the workflow `name` and before or after the `on` block. This ensures all jobs inherit these minimal permissions, unless overridden. There is no need for code or import changes elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
