### PR TITLE
Add custom labels for Fizz and Buzz

### DIFF
--- a/TestFizzBuzz.Tests/FizzBuzzTests.cs
+++ b/TestFizzBuzz.Tests/FizzBuzzTests.cs
@@ -82,4 +82,30 @@ public class FizzBuzzTests
         var resBoth = list.FizzBuzz(_ => true, _ => true).ToArray();
         Assert.All(resBoth, s => Assert.Equal("FizzBuzz", s));
     }
+
+    // New test: int overload with custom labels
+    [Fact]
+    public void FizzBuzz_IntCustomLabels()
+    {
+        var elems = Enumerable.Range(0, 16).ToArray();
+        var res = elems.FizzBuzz("F", "B").ToArray();
+
+        Assert.Equal("F", res[3]);
+        Assert.Equal("B", res[5]);
+        Assert.Equal("FB", res[15]);
+        Assert.Equal("1", res[1]);
+    }
+
+    // New test: generic overload with custom labels
+    [Fact]
+    public void FizzBuzz_GenericCustomLabels()
+    {
+        var elems = Enumerable.Range(0, 100).Select(t => t.ToString()).ToArray();
+        var res = elems.FizzBuzz(t => t.EndsWith('3'), t => t.EndsWith('5'), "X", "Y").ToArray();
+
+        Assert.Equal("X", res[3]);
+        Assert.Equal("Y", res[5]);
+        Assert.Equal("Y", res[15]);
+        Assert.Equal("21", res[21]);
+    }
 }

--- a/TestFizzBuzz/FizzBuzzExtensions.cs
+++ b/TestFizzBuzz/FizzBuzzExtensions.cs
@@ -11,41 +11,64 @@ namespace TestFizzBuzz;
 public static class FizzBuzzExtensions
 {
     /// <summary>
-    /// Performs FizzBuzz operation on the elements of the collection based on the provided predicates.
+    /// Performs FizzBuzz operation on the elements of the collection using the default Fizz and Buzz predicates.
     /// </summary>
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
     /// <param name="enumerable">The collection to perform FizzBuzz operation on.</param>
     /// <param name="testFizz">The predicate to test if an element should be replaced with the fizz label.</param>
     /// <param name="testBuzz">The predicate to test if an element should be replaced with the buzz label.</param>
-    /// <param name="fizzLabel">Label used when the fizz predicate matches. Defaults to "Fizz".</param>
-    /// <param name="buzzLabel">Label used when the buzz predicate matches. Defaults to "Buzz".</param>
     /// <returns>An enumerable of strings representing the FizzBuzz operation results.</returns>
-    public static IEnumerable<string> FizzBuzz<T>(this IEnumerable<T> enumerable, Predicate<T> testFizz, Predicate<T> testBuzz, string fizzLabel = "Fizz", string buzzLabel = "Buzz")
+    public static IEnumerable<string> FizzBuzz<T>(this IEnumerable<T> enumerable, Predicate<T> testFizz, Predicate<T> testBuzz)
+    {
+        return enumerable.FizzBuzz(testFizz, testBuzz, "Fizz", "Buzz");
+    }
+
+    /// <summary>
+    /// Performs FizzBuzz operation on the elements of the collection based on the provided predicates and explicit labels.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the collection.</typeparam>
+    /// <param name="enumerable">The collection to perform FizzBuzz operation on.</param>
+    /// <param name="testFizz">The predicate to test if an element should be replaced with the fizz label.</param>
+    /// <param name="testBuzz">The predicate to test if an element should be replaced with the buzz label.</param>
+    /// <param name="fizzLabel">Label used when the fizz predicate matches.</param>
+    /// <param name="buzzLabel">Label used when the buzz predicate matches.</param>
+    /// <returns>An enumerable of strings representing the FizzBuzz operation results.</returns>
+    public static IEnumerable<string> FizzBuzz<T>(this IEnumerable<T> enumerable, Predicate<T> testFizz, Predicate<T> testBuzz, string fizzLabel, string buzzLabel)
     {
         return enumerable.Select(i => FizzBuzzElem(i, testFizz, testBuzz, fizzLabel, buzzLabel));
     }
 
     /// <summary>
-    /// Performs FizzBuzz operation on the elements of the collection using the default Fizz and Buzz predicates.
+    /// Performs FizzBuzz operation on the elements of the collection using the standard divisibility predicates (3 and 5).
     /// </summary>
     /// <param name="enumerable">The collection to perform FizzBuzz operation on.</param>
-    /// <param name="fizzLabel">Label used when the fizz predicate matches. Defaults to "Fizz".</param>
-    /// <param name="buzzLabel">Label used when the buzz predicate matches. Defaults to "Buzz".</param>
     /// <returns>An enumerable of strings representing the FizzBuzz operation results.</returns>
-    public static IEnumerable<string> FizzBuzz(this IEnumerable<int> enumerable, string fizzLabel = "Fizz", string buzzLabel = "Buzz")
+    public static IEnumerable<string> FizzBuzz(this IEnumerable<int> enumerable)
+    {
+        return enumerable.FizzBuzz(t => t % 3 == 0, t => t % 5 == 0);
+    }
+
+    /// <summary>
+    /// Performs FizzBuzz operation on the elements of the collection using the standard divisibility predicates (3 and 5) with explicit labels.
+    /// </summary>
+    /// <param name="enumerable">The collection to perform FizzBuzz operation on.</param>
+    /// <param name="fizzLabel">Label used when the fizz predicate matches.</param>
+    /// <param name="buzzLabel">Label used when the buzz predicate matches.</param>
+    /// <returns>An enumerable of strings representing the FizzBuzz operation results.</returns>
+    public static IEnumerable<string> FizzBuzz(this IEnumerable<int> enumerable, string fizzLabel, string buzzLabel)
     {
         return enumerable.FizzBuzz(t => t % 3 == 0, t => t % 5 == 0, fizzLabel, buzzLabel);
     }
 
     /// <summary>
-    /// Performs FizzBuzz operation on a single element based on the provided predicates.
+    /// Performs FizzBuzz operation on a single element based on the provided predicates and labels.
     /// </summary>
     /// <typeparam name="T">The type of the element.</typeparam>
     /// <param name="i">The element to perform FizzBuzz operation on.</param>
     /// <param name="testFizz">The predicate to test if the element should be replaced with the fizz label.</param>
     /// <param name="testBuzz">The predicate to test if the element should be replaced with the buzz label.</param>
-    /// <param name="fizzLabel">Label used when the fizz predicate matches. Defaults to "Fizz".</param>
-    /// <param name="buzzLabel">Label used when the buzz predicate matches. Defaults to "Buzz".</param>
+    /// <param name="fizzLabel">Label used when the fizz predicate matches.</param>
+    /// <param name="buzzLabel">Label used when the buzz predicate matches.</param>
     /// <returns>A string representing the FizzBuzz operation result for the element.</returns>
     private static string FizzBuzzElem<T>(this T i, Predicate<T> testFizz, Predicate<T> testBuzz, string fizzLabel, string buzzLabel)
     {

--- a/TestFizzBuzz/FizzBuzzExtensions.cs
+++ b/TestFizzBuzz/FizzBuzzExtensions.cs
@@ -15,22 +15,26 @@ public static class FizzBuzzExtensions
     /// </summary>
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
     /// <param name="enumerable">The collection to perform FizzBuzz operation on.</param>
-    /// <param name="testFizz">The predicate to test if an element should be replaced with "Fizz".</param>
-    /// <param name="testBuzz">The predicate to test if an element should be replaced with "Buzz".</param>
+    /// <param name="testFizz">The predicate to test if an element should be replaced with the fizz label.</param>
+    /// <param name="testBuzz">The predicate to test if an element should be replaced with the buzz label.</param>
+    /// <param name="fizzLabel">Label used when the fizz predicate matches. Defaults to "Fizz".</param>
+    /// <param name="buzzLabel">Label used when the buzz predicate matches. Defaults to "Buzz".</param>
     /// <returns>An enumerable of strings representing the FizzBuzz operation results.</returns>
-    public static IEnumerable<string> FizzBuzz<T>(this IEnumerable<T> enumerable, Predicate<T> testFizz, Predicate<T> testBuzz)
+    public static IEnumerable<string> FizzBuzz<T>(this IEnumerable<T> enumerable, Predicate<T> testFizz, Predicate<T> testBuzz, string fizzLabel = "Fizz", string buzzLabel = "Buzz")
     {
-        return enumerable.Select(i => FizzBuzzElem(i, testFizz, testBuzz));
+        return enumerable.Select(i => FizzBuzzElem(i, testFizz, testBuzz, fizzLabel, buzzLabel));
     }
 
     /// <summary>
     /// Performs FizzBuzz operation on the elements of the collection using the default Fizz and Buzz predicates.
     /// </summary>
     /// <param name="enumerable">The collection to perform FizzBuzz operation on.</param>
+    /// <param name="fizzLabel">Label used when the fizz predicate matches. Defaults to "Fizz".</param>
+    /// <param name="buzzLabel">Label used when the buzz predicate matches. Defaults to "Buzz".</param>
     /// <returns>An enumerable of strings representing the FizzBuzz operation results.</returns>
-    public static IEnumerable<string> FizzBuzz(this IEnumerable<int> enumerable)
+    public static IEnumerable<string> FizzBuzz(this IEnumerable<int> enumerable, string fizzLabel = "Fizz", string buzzLabel = "Buzz")
     {
-        return enumerable.FizzBuzz(t => t % 3 == 0, t => t % 5 == 0);
+        return enumerable.FizzBuzz(t => t % 3 == 0, t => t % 5 == 0, fizzLabel, buzzLabel);
     }
 
     /// <summary>
@@ -38,10 +42,12 @@ public static class FizzBuzzExtensions
     /// </summary>
     /// <typeparam name="T">The type of the element.</typeparam>
     /// <param name="i">The element to perform FizzBuzz operation on.</param>
-    /// <param name="testFizz">The predicate to test if the element should be replaced with "Fizz".</param>
-    /// <param name="testBuzz">The predicate to test if the element should be replaced with "Buzz".</param>
+    /// <param name="testFizz">The predicate to test if the element should be replaced with the fizz label.</param>
+    /// <param name="testBuzz">The predicate to test if the element should be replaced with the buzz label.</param>
+    /// <param name="fizzLabel">Label used when the fizz predicate matches. Defaults to "Fizz".</param>
+    /// <param name="buzzLabel">Label used when the buzz predicate matches. Defaults to "Buzz".</param>
     /// <returns>A string representing the FizzBuzz operation result for the element.</returns>
-    private static string FizzBuzzElem<T>(this T i, Predicate<T> testFizz, Predicate<T> testBuzz)
+    private static string FizzBuzzElem<T>(this T i, Predicate<T> testFizz, Predicate<T> testBuzz, string fizzLabel, string buzzLabel)
     {
         if (!testFizz(i) && !testBuzz(i))
         {
@@ -50,11 +56,11 @@ public static class FizzBuzzExtensions
         var sb = new StringBuilder();
         if (testFizz(i))
         {
-            sb.Append("Fizz");
+            sb.Append(fizzLabel);
         }
         if (testBuzz(i))
         {
-            sb.Append("Buzz");
+            sb.Append(buzzLabel);
         }
         return sb.ToString();
     }


### PR DESCRIPTION
#### PR Classification
New feature to enhance the FizzBuzz functionality with custom labels.

#### PR Summary
This pull request introduces new unit tests for the FizzBuzz method and modifies the FizzBuzzExtensions class to support custom fizz and buzz labels. 
- `FizzBuzzTests.cs`: Added `FizzBuzz_IntCustomLabels` and `FizzBuzz_GenericCustomLabels` unit tests.
- `FizzBuzzExtensions.cs`: Updated `FizzBuzz` method signatures to include optional `fizzLabel` and `buzzLabel` parameters.
- `FizzBuzzExtensions.cs`: Adjusted `FizzBuzzElem` method to utilize custom labels in output generation.
